### PR TITLE
Add a gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,62 @@
+# Compiled Binaries
+*.exe
+
+# Build Directories and toolchain-generated files
+build/
+obj/
+bin/
+lib/
+x64/
+Debug/
+install/
+Release/
+*.layout
+*.depend
+scons-local*
+.sconsign.dblite
+/*.d
+/vcpkg/
+
+# Test Reports
+test-report.xml
+
+# User-installed plugins
+/plugins/
+
+# OS-specific generated files
+.DS_Store
+*.db
+
+# IDEs (no support implied)
+.cache
+.devcontainer
+.vscode
+.vs
+.metadata
+*.psess
+*.vsp
+*.vspx
+*.sap
+ipch/
+*.aps
+*.ncb
+*.opendb
+*.opensdf
+*.sdf
+*.cachefile
+*.VC.db
+*.VC.VC.opendb
+*.suo
+*.sln
+*.vcxproj*
+*.userosscache
+*.sln.docstates
+*.xcodeproj/**
+.idea/
+.idea_modules/
+compile_commands.json
+CMakeUserPresets.json
+.gitmodules
+
+# static code analysis
+/.scannerwork

--- a/.gitignore
+++ b/.gitignore
@@ -1,28 +1,6 @@
 # Compiled Binaries
 *.exe
 
-# Build Directories and toolchain-generated files
-build/
-obj/
-bin/
-lib/
-x64/
-Debug/
-install/
-Release/
-*.layout
-*.depend
-scons-local*
-.sconsign.dblite
-/*.d
-/vcpkg/
-
-# Test Reports
-test-report.xml
-
-# User-installed plugins
-/plugins/
-
 # OS-specific generated files
 .DS_Store
 *.db


### PR DESCRIPTION
Includes `*.exe` so the compiled binaries of the tools are ignored.
Also includes some IDE/editor, static-analysis program, and OS generated directories, copied from the .gitignore file of endless-sky/endless-sky.