### PR TITLE
Various other style fixes

### DIFF
--- a/add-minables.cpp
+++ b/add-minables.cpp
@@ -69,18 +69,18 @@ int main(int argc, char *argv[])
 	uniform_real_distribution<> real(0., 1.);
 	
 	map<string, double> probability = {
-		{"aluminum",  0.12},
-		{"copper",  0.08},
-		{"gold",  0.02},
-		{"iron",  0.13},
-		{"lead",  0.15},
-		{"neodymium",  0.03},
-		{"platinum",  0.01},
-		{"silicon",  0.2},
-		{"silver",  0.05},
-		{"titanium",  0.11},
-		{"tungsten",  0.06},
-		{"uranium",  0.04}
+		{"aluminum", 0.12},
+		{"copper", 0.08},
+		{"gold", 0.02},
+		{"iron", 0.13},
+		{"lead", 0.15},
+		{"neodymium", 0.03},
+		{"platinum", 0.01},
+		{"silicon", 0.2},
+		{"silver", 0.05},
+		{"titanium", 0.11},
+		{"tungsten", 0.06},
+		{"uranium", 0.04}
 	};
 	
 	bool skip = true;

--- a/add-minables.cpp
+++ b/add-minables.cpp
@@ -17,9 +17,9 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #include <cstdlib>
 #include <iostream>
 #include <map>
+#include <sstream>
 #include <string>
 #include <random>
-#include <sstream>
 
 using namespace std;
 
@@ -31,19 +31,19 @@ bool StartsWith(const string &line, const string &str)
 string Token(const string &line, int index)
 {
 	size_t pos = 0;
-	
+
 	while(pos < line.length())
 	{
 		while(line[pos] <= ' ')
 			++pos;
-		
+
 		char quote = 0;
 		if(line[pos] == '"' || line[pos] == '`')
 			quote = line[pos++];
 		size_t start = pos;
 		while(pos < line.length() && (quote ? (line[pos] != quote) : (line[pos] > ' ')))
 			++pos;
-		
+
 		if(!index--)
 			return line.substr(start, pos - start);
 		pos = pos + !!quote;
@@ -63,11 +63,11 @@ double Value(const string &line, int index)
 int main(int argc, char *argv[])
 {
 	srand(time(nullptr));
-	
+
 	random_device rd;
 	mt19937 gen(rd());
 	uniform_real_distribution<> real(0., 1.);
-	
+
 	map<string, double> probability = {
 		{"aluminum", 0.12},
 		{"copper", 0.08},
@@ -82,13 +82,13 @@ int main(int argc, char *argv[])
 		{"tungsten", 0.06},
 		{"uranium", 0.04}
 	};
-	
+
 	bool skip = true;
 	bool previousWasHabitable = false;
 	bool previousWasAsteroids = false;
 	int totalCount = 0;
 	double totalEnergy = 0.;
-	
+
 	string line;
 	while(getline(cin, line))
 	{
@@ -103,7 +103,7 @@ int main(int argc, char *argv[])
 			if(!skip)
 				cout << "\tbelt " << static_cast<int>(1000. + 1000. * real(gen)) << '\n';
 		}
-		
+
 		if(!skip && StartsWith(line, "\tasteroids"))
 		{
 			previousWasAsteroids = true;
@@ -116,9 +116,9 @@ int main(int argc, char *argv[])
 		{
 			previousWasAsteroids = false;
 			double meanEnergy = totalCount ? (totalEnergy / totalCount) : 0.;
-			
+
 			map<string, double> choices;
-			
+
 			// Minables should be much less prevalent than ordinary asteroids.
 			totalCount /= 4;
 			for(int i = 0; i < 3; ++i)
@@ -126,7 +126,7 @@ int main(int argc, char *argv[])
 				totalCount = rand() % (totalCount + 1);
 				if(!totalCount)
 					break;
-				
+
 				double choice = real(gen);
 				for(const auto &it : probability)
 				{

--- a/blend.cpp
+++ b/blend.cpp
@@ -1,11 +1,11 @@
 // g++ --std=c++0x blend.cpp -o blend -lpng
 
-#include <zlib.h>
 #include <png.h>
+#include <zlib.h>
 
+#include <algorithm>
 #include <iostream>
 #include <vector>
-#include <algorithm>
 
 using namespace std;
 
@@ -21,7 +21,7 @@ int main(int argc, char *argv[])
 		cout << "Usage: $ blend <opaque image> <additive image> <result image>" << endl;
 		return 1;
 	}
-	
+
 	int ow = 0, oh = 0;
 	uint32_t *op = Read(argv[1], &ow, &oh);
 	if(!op)
@@ -29,7 +29,7 @@ int main(int argc, char *argv[])
 		cerr << "Unable to read image: " << argv[1] << endl;
 		return 1;
 	}
-	
+
 	int aw = 0, ah = 0;
 	uint32_t *ap = Read(argv[2], &aw, &ah);
 	if(!op)
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
 		delete [] op;
 		return 1;
 	}
-	
+
 	if(ow != aw || oh != ah)
 	{
 		cerr << "Images are different sizes: " << ow << "x" << oh << " versus "
@@ -47,34 +47,34 @@ int main(int argc, char *argv[])
 		delete [] ap;
 		return 1;
 	}
-	
+
 	for(int y = 0; y < oh; ++y)
 	{
 		uint32_t *oit = op + y * ow;
 		uint32_t *ait = ap + y * aw;
-		
+
 		for(uint32_t *oend = oit + ow; oit != oend; ++oit, ++ait)
 		{
 			uint64_t oA = (*oit >> 24) & 0xFF;
 			uint64_t oR = (*oit >> 16) & 0xFF;
 			uint64_t oG = (*oit >> 8) & 0xFF;
 			uint64_t oB = (*oit >> 0) & 0xFF;
-			
+
 			uint64_t aA = (*ait >> 24) & 0xFF;
 			uint64_t aR = (*ait >> 16) & 0xFF;
 			uint64_t aG = (*ait >> 8) & 0xFF;
 			uint64_t aB = (*ait >> 0) & 0xFF;
-			
+
 			oR = min(uint64_t(255), (oR * oA) / 255 + (aR * aA) / 255);
 			oG = min(uint64_t(255), (oG * oA) / 255 + (aG * aA) / 255);
 			oB = min(uint64_t(255), (oB * oA) / 255 + (aB * aA) / 255);
-			
+
 			*oit = static_cast<uint32_t>((oA << 24) + (oR << 16) + (oG << 8) + (oB << 0));
 		}
 	}
-	
+
 	Write(argv[3], op, ow, oh);
-	
+
 	return 0;
 }
 
@@ -85,19 +85,19 @@ uint32_t *Read(const char *path, int *width, int *height)
 	FILE *file = fopen(path, "rb");
 	if(!file)
 		return nullptr;
-	
+
 	// Set up libpng.
 	png_struct *png = png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
 	if(!png)
 		return nullptr;
-	
+
 	png_info *info = png_create_info_struct(png);
 	if(!info)
 	{
 		png_destroy_read_struct(&png, nullptr, nullptr);
 		return nullptr;
 	}
-	
+
 	uint32_t *buffer = nullptr;
 	if(setjmp(png_jmpbuf(png)))
 	{
@@ -105,20 +105,20 @@ uint32_t *Read(const char *path, int *width, int *height)
 		delete buffer;
 		return nullptr;
 	}
-	
+
 	png_init_io(png, file);
 	png_set_sig_bytes(png, 0);
-	
+
 	png_read_info(png, info);
 	*width = png_get_image_width(png, info);
 	*height = png_get_image_height(png, info);
 	if(!*width || !*height)
 		return nullptr;
-	
+
 	// Adjust settings to make sure the result will be a BGRA file.
 	int colorType = png_get_color_type(png, info);
 	int bitDepth = png_get_bit_depth(png, info);
-	
+
 	png_set_strip_16(png);
 	png_set_packing(png);
 	if(colorType == PNG_COLOR_TYPE_PALETTE)
@@ -128,19 +128,19 @@ uint32_t *Read(const char *path, int *width, int *height)
 	if(colorType & PNG_COLOR_MASK_COLOR)
 		png_set_bgr(png);
 	png_read_update_info(png, info);
-	
+
 	// Read the file.
 	buffer = new uint32_t[*width * *height];
 	vector<png_byte *> rows;
 	for(int y = 0; y < *height; ++y)
 		rows.push_back(reinterpret_cast<png_byte *>(buffer + y * *width));
-	
+
 	png_read_image(png, &rows.front());
-	
+
 	// Clean up.
 	png_destroy_read_struct(&png, &info, nullptr);
 	fclose(file);
-	
+
 	return buffer;
 }
 
@@ -152,38 +152,38 @@ void Write(const char *path, uint32_t *buffer, int width, int height)
 	png_struct *png = png_create_write_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
 	if(!png)
 		return;
-	
+
 	png_info *info = png_create_info_struct(png);
 	if(!info)
 	{
 		png_destroy_read_struct(&png, nullptr, nullptr);
 		return;
 	}
-	
+
 	if(setjmp(png_jmpbuf(png)))
 	{
 		png_destroy_read_struct(&png, &info, nullptr);
 		return;
 	}
-	
+
 	FILE *file = fopen(path, "wb");
 	png_init_io(png, file);
 	png_set_compression_level(png, Z_BEST_COMPRESSION);
-	
+
 	png_set_IHDR(png, info, width, height, 8,
 		PNG_COLOR_TYPE_RGB_ALPHA, PNG_INTERLACE_NONE,
 		PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
-	
+
 	png_set_bgr(png);
 	png_write_info(png, info);
-	
+
 	vector<png_byte *> rows;
 	for(int y = 0; y < height; ++y)
 		rows.push_back(reinterpret_cast<png_byte *>(buffer + y * width));
-	
+
 	png_write_image(png, &rows.front());
 	png_write_end(png, NULL);
-	
+
 	// Clean up.
 	png_destroy_write_struct(&png, &info);
 	fclose(file);

--- a/dynamic-economy.cpp
+++ b/dynamic-economy.cpp
@@ -146,7 +146,7 @@ int main(int argc, char *argv[])
 			for(const auto &it : links)
 				if(it.second.size())
 				{
-					double share = trade[it.first] /it.second.size();
+					double share = trade[it.first] / it.second.size();
 					for(const string &link : it.second)
 						supply[link] += share;
 				}

--- a/dynamic-economy.cpp
+++ b/dynamic-economy.cpp
@@ -3,14 +3,14 @@
 // $ g++ --std=c++11 -o dynamic-economy dynamic-economy.cpp
 // $ ./dynamic-economy path/to/map.txt
 
-#include <iostream>
+#include <cmath>
 #include <fstream>
-#include <string>
+#include <iostream>
 #include <map>
+#include <random>
 #include <set>
 #include <sstream>
-#include <cmath>
-#include <random>
+#include <string>
 
 using namespace std;
 
@@ -22,19 +22,19 @@ bool StartsWith(const string &line, const string &str)
 string Token(const string &line, int index)
 {
 	size_t pos = 0;
-	
+
 	while(pos < line.length())
 	{
 		while(line[pos] <= ' ')
 			++pos;
-		
+
 		char quote = 0;
 		if(line[pos] == '"' || line[pos] == '`')
 			quote = line[pos++];
 		size_t start = pos;
 		while(pos < line.length() && (quote ? (line[pos] != quote) : (line[pos] > ' ')))
 			++pos;
-		
+
 		if(!index--)
 			return line.substr(start, pos - start);
 		pos = pos + !!quote;
@@ -72,23 +72,23 @@ int main(int argc, char *argv[])
 {
 	if(argc < 2)
 		return 1;
-	
+
 	mt19937_64 gen;
 	gen.seed(12345);
 	normal_distribution<double> normal;
-	
+
 	map<string, double> posX;
 	map<string, double> posY;
 	map<string, set<string>> links;
-	
+
 	double minX = 0.;
 	double maxX = 0.;
 	double minY = 0.;
 	double maxY = 0.;
-	
+
 	string line;
 	string name;
-	
+
 	ifstream in(argv[1]);
 	while(getline(in, line))
 	{
@@ -108,7 +108,7 @@ int main(int argc, char *argv[])
 		else if(StartsWith(line, "\tlink") && !name.empty())
 			links[name].insert(Token(line, 1));
 	}
-	
+
 	// Add a slight border around the edges.
 	const double BORDER = .05;
 	double xBorder = (maxX - minX) * BORDER;
@@ -124,7 +124,7 @@ int main(int argc, char *argv[])
 	double scale = MAX_DIMENSION / max(maxX - minX, maxY - minY);
 	int width = scale * (maxX - minX);
 	int height = scale * (maxY - minY);
-	
+
 	// Run the simulation repeatedly.
 	map<string, double> supply;
 	map<string, double> trade;
@@ -154,11 +154,11 @@ int main(int argc, char *argv[])
 		// After the first day, step according to the given step size.
 		if(argc > 2)
 			DAYS = stoi(argv[2]);
-	
+
 		ofstream out("economy.svg");
 		out << "<svg width=\"" << width << "\" height=\"" << height << "\">" << endl;
 		out << "<rect width=\"" << width << "\" height=\"" << height << "\" fill=\"black\" />" << endl;
-	
+
 		// Draw the links.
 		for(const auto &it : posX)
 		{
@@ -172,12 +172,12 @@ int main(int argc, char *argv[])
 					continue;
 				double x2 = (posX[link] - minX) * scale;
 				double y2 = (posY[link] - minY) * scale;
-			
+
 				out << "<line x1=\"" << x1 << "\" y1=\"" << y1 << "\" x2=\"" << x2 << "\" y2=\"" << y2
 					<< "\" style=\"stroke:#444444;stroke-width:1.5\" />" << endl;
 			}
 		}
-	
+
 		// Draw circles for the systems.
 		double lowest = 1.;
 		double highest = -1.;
@@ -191,14 +191,14 @@ int main(int argc, char *argv[])
 			highest = max(value, highest);
 			double r, g, b;
 			MapColor(value, &r, &g, &b);
-		
+
 			out << "<circle cx=\"" << x << "\" cy=\"" << y << "\" r=\"" << RADIUS
 				<< "\" fill=\"rgb(" << r << "%, " << g << "%, " << b << "%)\" />" << endl;
 		}
-	
+
 		out << "</svg>" << endl;
 		out.close();
-		
+
 		cout << "Adjustment range: " << lowest << " to " << highest;
 		cin.get();
 		if(!cin)

--- a/file-check.cpp
+++ b/file-check.cpp
@@ -2,8 +2,8 @@
 // $ g++ --std=c++11 -o file-check file-check.cpp
 // $ ./file-check path/to/data/*.txt
 
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
 using namespace std;
 
@@ -14,15 +14,15 @@ int main(int argc, char *argv[])
 	for(char **it = argv + 1; *it; ++it)
 	{
 		ifstream in(*it, ios::binary);
-		
+
 		in.seekg(0, ios::end);
 		size_t bytes = in.tellg();
 		in.seekg(0, ios::beg);
-		
+
 		char *data = new char[bytes];
 		in.read(data, bytes);
 		char *end = data + bytes;
-		
+
 		int line = 1;
 		int pos = 1;
 		for(char *cit = data; cit < end; ++cit, ++pos)
@@ -42,10 +42,10 @@ int main(int argc, char *argv[])
 		}
 		if(bytes && end[-1] != '\n')
 			cerr << *it << ": File does not end with a newline." << endl;
-		
+
 		delete [] data;
 	}
-	
+
 	return 0;
 }
 

--- a/freetype.cpp
+++ b/freetype.cpp
@@ -1,7 +1,7 @@
 // g++ -o freetype freetype.cpp `pkg-config --cflags --libs freetype2`
-#include <vector>
-#include <iostream>
 #include <fstream>
+#include <iostream>
+#include <vector>
 
 #include <freetype2/ft2build.h>
 #include FT_FREETYPE_H
@@ -36,13 +36,13 @@ int main(int argc, char *argv[])
 {
 	FT_Library library;
 	FT_Init_FreeType(&library);
-	
+
 	FT_Face face;
 	FT_New_Face(library, filename, 0, &face);
-	
+
 	FT_Set_Char_Size(face, FONT_SIZE * 64, 0, DPI, 0);
 	FT_GlyphSlot slot = face->glyph;
-	
+
 	// Hint the font for normal DPI, but render it at high DPI.
 	FT_Matrix transform;
 	transform.xx = 0x20000; transform.xy = 0x00000;
@@ -51,7 +51,7 @@ int main(int argc, char *argv[])
 	offset.x = 0;
 	offset.y = 0;
 	FT_Set_Transform(face, &transform, &offset);
-	
+
 	vector<unsigned char> image(WIDTH * HEIGHT, 0);
 	vector<unsigned char>::iterator start = image.begin();
 	for(int n = 32; n < 130; ++n)
@@ -67,18 +67,18 @@ int main(int argc, char *argv[])
 		if(n == 129)
 			trueN = 0x201C;
 		FT_Load_Char(face, trueN, FT_LOAD_RENDER | FT_LOAD_FORCE_AUTOHINT);
-		
+
 		/*cout << n << '\t' << "'" << char(n) << '\t' << slot->bitmap.width << '\t'
 			<< slot->bitmap.rows << '\t' << slot->bitmap_left << '\t'
 			<< slot->bitmap_top << endl;*/
-		
+
 		// Copy the glyph into the output bitmap.
 		for(int row = 0; row < slot->bitmap.rows; ++row)
 		{
 			int y = BASE - slot->bitmap_top + row;
 			if(y < 0 || y >= CHAR_H)
 				continue;
-			
+
 			vector<unsigned char>::iterator it = start + WIDTH * (CHAR_H - 1 - y) + LEFT;
 			// If drawing at 2x resolution, match the 1x resolution alignment.
 			if(slot->bitmap_left & 1)
@@ -88,11 +88,11 @@ int main(int argc, char *argv[])
 		}
 		start += GLYPH_PITCH;
 	}
-	
+
 	ofstream out("font.bmp", ios::out | ios::binary);
 	out.put('B');
 	out.put('M');
-	
+
 	unsigned size = WIDTH * HEIGHT * 4 + 54;
 	out.put((size >> 0) & 0xFF);
 	out.put((size >> 8) & 0xFF);
@@ -106,7 +106,7 @@ int main(int argc, char *argv[])
 	out.put(0);
 	out.put(0);
 	out.put(0);
-	
+
 	out.put(40);
 	out.put(0);
 	out.put(0);
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
 	out.put(0);
 	for(int i = 0; i < 24; ++i)
 		out.put(0);
-	
+
 	for(vector<unsigned char>::iterator it = image.begin(); it != image.end(); ++it)
 	{
 		out.put(*it);
@@ -133,6 +133,6 @@ int main(int argc, char *argv[])
 		out.put(*it);
 		out.put(255);
 	}
-	
+
 	return 0;
 }

--- a/freetype.cpp
+++ b/freetype.cpp
@@ -10,12 +10,12 @@ using namespace std;
 
 static const int GLYPHS = 98;
 
-/*static const int FONT_SIZE = 14;
-static const int CHAR_W = 28;
-static const int CHAR_H = 32;
-static const int BASE = 26;
-static const int LEFT = 2;
-static const int DPI = 72;*/
+// static const int FONT_SIZE = 14;
+// static const int CHAR_W = 28;
+// static const int CHAR_H = 32;
+// static const int BASE = 26;
+// static const int LEFT = 2;
+// static const int DPI = 72;
 
 static const int FONT_SIZE = 18;
 static const int CHAR_W = 36;

--- a/freetype.cpp
+++ b/freetype.cpp
@@ -68,9 +68,9 @@ int main(int argc, char *argv[])
 			trueN = 0x201C;
 		FT_Load_Char(face, trueN, FT_LOAD_RENDER | FT_LOAD_FORCE_AUTOHINT);
 
-		/*cout << n << '\t' << "'" << char(n) << '\t' << slot->bitmap.width << '\t'
-			<< slot->bitmap.rows << '\t' << slot->bitmap_left << '\t'
-			<< slot->bitmap_top << endl;*/
+		// cout << n << '\t' << "'" << char(n) << '\t' << slot->bitmap.width << '\t'
+			// << slot->bitmap.rows << '\t' << slot->bitmap_left << '\t'
+			// << slot->bitmap_top << endl;
 
 		// Copy the glyph into the output bitmap.
 		for(int row = 0; row < slot->bitmap.rows; ++row)

--- a/freetype.cpp
+++ b/freetype.cpp
@@ -45,8 +45,10 @@ int main(int argc, char *argv[])
 
 	// Hint the font for normal DPI, but render it at high DPI.
 	FT_Matrix transform;
-	transform.xx = 0x20000; transform.xy = 0x00000;
-	transform.yx = 0x00000; transform.yy = 0x20000;
+	transform.xx = 0x20000;
+	transform.xy = 0x00000;
+	transform.yx = 0x00000;
+	transform.yy = 0x20000;
 	FT_Vector offset;
 	offset.x = 0;
 	offset.y = 0;

--- a/mapper.cpp
+++ b/mapper.cpp
@@ -2,12 +2,12 @@
 // $ g++ --std=c++11 -o mapper mapper.cpp
 // $ ./mapper path/to/map.txt path/to/governments.txt > map.svg
 
-#include <iostream>
 #include <fstream>
-#include <string>
+#include <iostream>
 #include <map>
 #include <set>
 #include <sstream>
+#include <string>
 
 using namespace std;
 
@@ -19,19 +19,19 @@ bool StartsWith(const string &line, const string &str)
 string Token(const string &line, int index)
 {
 	size_t pos = 0;
-	
+
 	while(pos < line.length())
 	{
 		while(line[pos] <= ' ')
 			++pos;
-		
+
 		char quote = 0;
 		if(line[pos] == '"' || line[pos] == '`')
 			quote = line[pos++];
 		size_t start = pos;
 		while(pos < line.length() && (quote ? (line[pos] != quote) : (line[pos] > ' ')))
 			++pos;
-		
+
 		if(!index--)
 			return line.substr(start, pos - start);
 		pos = pos + !!quote;
@@ -69,25 +69,25 @@ int main(int argc, char *argv[])
 {
 	if(argc <= 1)
 		return 1;
-	
+
 	map<string, double> posX;
 	map<string, double> posY;
 	map<string, string> gov;
 	map<string, double> trade;
 	map<string, set<string>> links;
-	
+
 	map<string, double> govR;
 	map<string, double> govG;
 	map<string, double> govB;
-	
+
 	double minX = 0.;
 	double maxX = 0.;
 	double minY = 0.;
 	double maxY = 0.;
-	
+
 	string line;
 	string name;
-	
+
 	// First, read the government file, if any.
 	string commodity;
 	double tradeMin = 0.;
@@ -96,7 +96,7 @@ int main(int argc, char *argv[])
 	{
 		commodity = argv[3];
 		ifstream in(argv[2]);
-		
+
 		while(getline(in, line))
 			if(StartsWith(line, "\tcommodity") && Token(line, 1) == commodity)
 			{
@@ -107,7 +107,7 @@ int main(int argc, char *argv[])
 	else if(argv[2])
 	{
 		ifstream in(argv[2]);
-		
+
 		while(getline(in, line))
 		{
 			if(StartsWith(line, "government"))
@@ -121,7 +121,7 @@ int main(int argc, char *argv[])
 		}
 		name.clear();
 	}
-	
+
 	// Now, parse the map.
 	ifstream in(argv[1]);
 	while(getline(in, line))
@@ -148,7 +148,7 @@ int main(int argc, char *argv[])
 		else if(!StartsWith(line, "\t"))
 			name.clear();
 	}
-	
+
 	// Add a slight border around the edges.
 	const double BORDER = .05;
 	double xBorder = (maxX - minX) * BORDER;
@@ -157,7 +157,7 @@ int main(int argc, char *argv[])
 	double yBorder = (maxY - minY) * BORDER;
 	minY -= yBorder;
 	maxY += yBorder;
-	
+
 	// Figure out the scale to apply to the map to keep dimensions below...
 	const double MAX_DIMENSION = 600.;
 	double scale = MAX_DIMENSION / max(maxX - minX, maxY - minY);
@@ -165,7 +165,7 @@ int main(int argc, char *argv[])
 	int height = scale * (maxY - minY);
 	cout << "<svg width=\"" << width << "\" height=\"" << height << "\">" << endl;
 	cout << "<rect width=\"" << width << "\" height=\"" << height << "\" fill=\"black\" />" << endl;
-	
+
 	// Draw the links.
 	for(const auto &it : posX)
 	{
@@ -179,12 +179,12 @@ int main(int argc, char *argv[])
 				continue;
 			double x2 = (posX[link] - minX) * scale;
 			double y2 = (posY[link] - minY) * scale;
-			
+
 			cout << "<line x1=\"" << x1 << "\" y1=\"" << y1 << "\" x2=\"" << x2 << "\" y2=\"" << y2
 				<< "\" style=\"stroke:#666666\" />" << endl;
 		}
 	}
-	
+
 	// Draw circles for the systems.
 	const double RADIUS = 2.;
 	for(const auto &it : posX)
@@ -207,11 +207,11 @@ int main(int argc, char *argv[])
 		}
 		else
 			cerr << system << endl;
-		
+
 		cout << "<circle cx=\"" << x << "\" cy=\"" << y << "\" r=\"" << RADIUS
 			<< "\" fill=\"rgb(" << r << "%, " << g << "%, " << b << "%)\" />" << endl;
 	}
-	
+
 	cout << "</svg>" << endl;
 	return 0;
 }

--- a/shared/DataWriter.h
+++ b/shared/DataWriter.h
@@ -13,8 +13,8 @@ PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 #ifndef DATA_WRITER_H_
 #define DATA_WRITER_H_
 
-#include <string>
 #include <sstream>
+#include <string>
 
 class DataNode;
 
@@ -28,27 +28,27 @@ class DataNode;
 class DataWriter {
 public:
 	DataWriter();
-	
+
 	string ToString() const;
-	
+
   template <class A, class ...B>
 	void Write(const A &a, B... others);
 	void Write(const DataNode &node);
 	void Write();
-	
+
 	void BeginChild();
 	void EndChild();
-	
+
 	void WriteComment(const std::string &str);
 	void AddLineBreak();
-	
+
 	// Write a token, without writing a whole line. Use this very carefully.
 	void WriteToken(const char *a);
 	void WriteToken(const std::string &a);
   template <class A>
 	void WriteToken(const A &a);
-	
-	
+
+
 private:
 	std::string indent;
 	static const std::string space;
@@ -72,7 +72,7 @@ void DataWriter::WriteToken(const A &a)
 {
 	static_assert(std::is_arithmetic<A>::value,
 		"DataWriter cannot output anything but strings and arithmetic types.");
-	
+
 	out << *before << a;
 	before = &space;
 }

--- a/worldview.cpp
+++ b/worldview.cpp
@@ -5,14 +5,14 @@
 #include "shared/DataFile.cpp"
 #include "shared/DataNode.cpp"
 
-#include <vector>
-#include <map>
-#include <string>
-#include <iostream>
-#include <limits>
 #include <algorithm>
 #include <fstream>
+#include <iostream>
+#include <limits>
+#include <map>
 #include <set>
+#include <string>
+#include <vector>
 
 using namespace std;
 
@@ -21,7 +21,7 @@ namespace {
 	double minY = numeric_limits<double>::infinity();
 	double maxX = -numeric_limits<double>::infinity();
 	double maxY = -numeric_limits<double>::infinity();
-	
+
 	map<string, int> uses;
 }
 
@@ -48,7 +48,7 @@ static const vector<Commodity> commodities = {
 class System {
 public:
 	void Load(const DataNode &node);
-	
+
 	const DataNode *root;
 	double x;
 	double y;
@@ -63,7 +63,7 @@ public:
 class Planet {
 public:
 	void Load(const DataNode &node);
-	
+
 	string landscape;
 	string description;
 	string spaceport;
@@ -80,9 +80,9 @@ int main(int argc, char *argv[])
 {
 	if(argc < 2)
 		return 1;
-	
+
 	DataFile file(argv[1]);
-	
+
 	map<string, System> systems;
 	map<string, Planet> planets;
 	for(const DataNode &node : file)
@@ -92,7 +92,7 @@ int main(int argc, char *argv[])
 		else if(node.Token(0) == "planet" && node.Size() >= 2)
 			planets[node.Token(1)].Load(node);
 	}
-	
+
 	// Draw all systems:
 	ofstream mapFile("map.svg");
 	mapFile << "<svg width=\"240\" height=\"240\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n";
@@ -103,7 +103,7 @@ int main(int argc, char *argv[])
 	for(const pair<string, System> &it : systems)
 	{
 		const System &system = it.second;
-		
+
 		double x1 = (system.x - centerX) * scale + radius;
 		double y1 = (system.y - centerY) * scale + radius;
 		for(const string &link : system.links)
@@ -111,14 +111,14 @@ int main(int argc, char *argv[])
 			// Only draw links in one direction.
 			if(link <= it.first)
 				continue;
-			
+
 			map<string, System>::iterator lit = systems.find(link);
 			if(lit == systems.end())
 				continue;
-			
+
 			double x2 = (lit->second.x - centerX) * scale + radius;
 			double y2 = (lit->second.y - centerY) * scale + radius;
-			
+
 			mapFile << "\n<line x1=\"" << x1 << "\" y1=\"" << y1
 				<< "\" x2=\"" << x2 << "\" y2=\"" << y2
 				<< "\" stroke=\"#333\" stroke-width=\"1.4\"/>";
@@ -126,7 +126,7 @@ int main(int argc, char *argv[])
 	}
 	mapFile << "\n</svg>\n";
 	mapFile.close();
-	
+
 	cout << "<html><head><title>World Viewer</title>" << endl;
 	cout << "<style>p {margin-top: 0.2em; margin-bottom: 0.2em; line-height: 150%;}</style></head>" << endl;
 	cout << "<body style=\"background-color:black; color:white;\"><table>" << endl;
@@ -135,30 +135,30 @@ int main(int argc, char *argv[])
 		size_t count = it.second.planets.size();
 		if(!count)
 			continue;
-		
+
 		cout << "<tr><td align=\"center\" valign=\"top\" rowspan=\"" << count
 			<< "\">" << it.first;
 		for(const string &star : it.second.stars)
 			cout << "<br/><img src=\"../images/" << star << ".png\">";
 		cout << "<p>Government: " << it.second.government << "</p>";
-		
+
 		// Draw system location:
 		double x = (it.second.x - centerX) * scale + radius;
 		double y = (it.second.y - centerY) * scale + radius;
-		
+
 		cout << "<svg width=\"240\" height=\"240\">";
 		cout << "<image x=\"0\" y=\"0\" width=\"240\" height=\"240\" xlink:href=\"map.svg\"/>";
 		cout << "<circle cx=\"" << x << "\" cy=\"" << y
 			<< "\" r=\"2\" fill=\"#FC3\" stroke=\"none\"/>";
 		cout << "</svg><br/>\n";
-		
+
 		cout << "<table>";
 		for(const Commodity &commodity : commodities)
 		{
 			auto cit = it.second.trade.find(commodity.name);
 			if(cit == it.second.trade.end())
 				continue;
-			
+
 			int price = cit->second;
 			int third = (commodity.high - commodity.low) / 3;
 			string color = (price < commodity.low + third) ? "#6699FF"
@@ -167,7 +167,7 @@ int main(int argc, char *argv[])
 				<< commodity.name << "</td><td>" << price << "</td></tr>";
 		}
 		cout << "</table><p>&nbsp;</p><p>&nbsp;</p><p>&nbsp;</p></td>" << endl;
-		
+
 		bool first = true;
 		for(const pair<string, string> &planet : it.second.planets)
 		{
@@ -175,19 +175,19 @@ int main(int argc, char *argv[])
 				cout << "<tr>";
 			cout << "<td valign=\"top\" align=\"center\">" << planet.first;
 			cout << "<br/><img src=\"../images/" << planet.second << ".png\">\n";
-			
+
 			const Planet &data = planets[planet.first];
 			cout << "<p style=\"color:#666\">(" << uses[planet.second] << " / "
 				<< uses[data.landscape] << " uses.</p>";
-			
+
 			// Draw the star system, with this planet highlighted.
 			double distance = MaxDistance(*it.second.root);
 			double scale = min(.03, 116. / distance);
-	
+
 			cout << "<svg width=\"240\" height=\"240\">";
 			Draw(*it.second.root, 120., 120., scale, planet.first);
 			cout << "</svg>\n";
-			
+
 			if(!data.shipyard.empty())
 			{
 				cout << "<p>Shipyard:</p>" << endl;
@@ -216,7 +216,7 @@ int main(int argc, char *argv[])
 			if(!first)
 				cout << "</tr>";
 			cout << endl;
-			
+
 			first = false;
 		}
 		cout << "</tr>" << endl;
@@ -230,7 +230,7 @@ void System::Load(const DataNode &node)
 {
 	if(node.Token(0) == "system")
 		root = &node;
-	
+
 	for(const DataNode &child : node)
 	{
 		if(child.Token(0) == "object")
@@ -245,7 +245,7 @@ void System::Load(const DataNode &node)
 				planets.push_back(planet);
 				seenPlanets.insert(planet.first);
 			}
-			// Recurse into 			
+			// Recurse into
 			Load(child);
 		}
 		else if(child.Token(0) == "sprite" && child.Size() >= 2)
@@ -265,7 +265,7 @@ void System::Load(const DataNode &node)
 			x = child.Value(1);
 			minX = min(minX, x);
 			maxX = max(maxX, x);
-			
+
 			y = child.Value(2);
 			minY = min(minY, y);
 			maxY = max(maxY, y);
@@ -308,7 +308,7 @@ void Planet::Load(const DataNode &node)
 double MaxDistance(const DataNode &node, double d)
 {
 	double maximum = d;
-	
+
 	for(const DataNode &child : node)
 	{
 		if(child.Token(0) == "object")
@@ -334,7 +334,7 @@ void Draw(const DataNode &node, double x, double y, double scale, const string &
 		cout << "<circle cx=\"" << x << "\" cy=\"" << y
 			<< "\" r=\"2\" fill=\"#39F\" stroke=\"none\"/>";
 	}
-	
+
 	for(const DataNode &child : node)
 	{
 		if(child.Token(0) == "object")
@@ -351,12 +351,12 @@ void Draw(const DataNode &node, double x, double y, double scale, const string &
 				else if(grand.Token(0) == "offset")
 					offset = grand.Value(1);
 			}
-			
+
 			distance *= scale;
 			distance += 1.;
 			cout << "<circle cx=\"" << x << "\" cy=\"" << y << "\" r=\"" << distance
 				<< "\" stroke=\"#333\" stroke-width=\"1.4\" fill=\"none\"/>";
-			
+
 			double angle = (offset + 100000. / period) * 0.017453293;
 			Draw(child, x + distance * sin(angle), y + distance * cos(angle), scale, name);
 		}

--- a/worldview.cpp
+++ b/worldview.cpp
@@ -95,7 +95,8 @@ int main(int argc, char *argv[])
 
 	// Draw all systems:
 	ofstream mapFile("map.svg");
-	mapFile << "<svg width=\"240\" height=\"240\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n";
+	mapFile << "<svg width=\"240\" height=\"240\" xmlns=\"http://www.w3.org/2000/svg\" "
+			"xmlns:xlink=\"http://www.w3.org/1999/xlink\">\n";
 	double radius = 120.;
 	double scale = 2. * (radius - 1.) / max(maxX - minX, maxY - minY);
 	double centerX = (minX + maxX) / 2.;


### PR DESCRIPTION
- Alphabetise `include`s throughout.
- Remove double spaces in a map initialisation in add-minables.cpp.
- Correct whitespace style around an operator in dynamic-economy.cpp.
- Remove multi-line comments in freetype.cpp.
- Split multi-statement lines in freetype.cpp.
- Split a line that exceeds 120 characters in worldview.cpp.