### PR TITLE
bugfix: Fix incorrect delimiting of strings

### DIFF
--- a/source/shared/DataWriter.cpp
+++ b/source/shared/DataWriter.cpp
@@ -103,6 +103,13 @@ void DataWriter::AddLineBreak()
 
 void DataWriter::WriteToken(const char *a)
 {
+	WriteToken(string(a));
+}
+
+
+
+void DataWriter::WriteToken(const string &a)
+{
 	// Figure out what kind of quotation marks need to be used for this string.
 	bool hasSpace = any_of(a.begin(), a.end(), [](char c) { return isspace(c); });
 	bool hasQuote = any_of(a.begin(), a.end(), [](char c) { return (c == '"'); });
@@ -115,11 +122,4 @@ void DataWriter::WriteToken(const char *a)
 	else
 		out << a;
 	before = &space;
-}
-
-
-
-void DataWriter::WriteToken(const string &a)
-{
-	WriteToken(a.c_str());
 }

--- a/source/shared/DataWriter.cpp
+++ b/source/shared/DataWriter.cpp
@@ -103,16 +103,12 @@ void DataWriter::AddLineBreak()
 
 void DataWriter::WriteToken(const char *a)
 {
-	bool hasSpace = !*a;
-	bool hasQuote = false;
-	for(const char *it = a; *it; ++it)
-	{
-		hasSpace |= (*it <= ' ');
-		hasQuote |= (*it == '"');
-	}
-
+	// Figure out what kind of quotation marks need to be used for this string.
+	bool hasSpace = any_of(a.begin(), a.end(), [](char c) { return isspace(c); });
+	bool hasQuote = any_of(a.begin(), a.end(), [](char c) { return (c == '"'); });
+	// Write the token, enclosed in quotes if necessary.
 	out << *before;
-	if(hasSpace && hasQuote)
+	if(hasQuote)
 		out << '`' << a << '`';
 	else if(hasSpace)
 		out << '"' << a << '"';


### PR DESCRIPTION
Same bug as in the base game, same bugfix.

The most minimalistic bugfix would be to just remove the `hasSpace &&`, but this is more in line with what's PRd for the main repo.